### PR TITLE
Fix conda environment and cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,6 @@ include_directories(${EIGEN3_INCLUDE_DIR} ${ARMADILLO_INCLUDE_DIRS} ${BLITZ_INCL
 include_directories(${xtl_INCLUDE_DIRS} ${xsimd_INCLUDE_DIRS} ${xtensor_INCLUDE_DIRS})
 include_directories(${Pythonic_INCLUDE_DIRS})
 
-# Add googlebenchmark directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src
-                 ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-build)
-
-set(GBENCHMARK_INCLUDE_DIRS "${googlebenchmark_SOURCE_DIR}/include")
-set(GBENCHMARK_LIBRARIES benchmark)
 
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
 include(CheckCXXCompilerFlag)
@@ -62,6 +55,15 @@ execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
                 RESULT_VARIABLE result
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-download )
+
+# Add googlebenchmark directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-build)
+
+set(GBENCHMARK_INCLUDE_DIRS "${googlebenchmark_SOURCE_DIR}/include")
+set(GBENCHMARK_LIBRARIES benchmark)
+
 
 add_definitions(-DXTENSOR_USE_XSIMD)
 add_definitions(-DEIGEN_FAST_MATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,17 @@ find_package(Threads)
 find_package(Eigen3)
 find_package(Blitz)
 find_package(Armadillo)
-find_package(Pythonic)
+find_package(PythonLibs)
+find_package(NumPy)
+find_package(Pythran)
 
 include_directories(${EIGEN3_INCLUDE_DIR} ${ARMADILLO_INCLUDE_DIRS} ${BLITZ_INCLUDES})
 include_directories(${xtl_INCLUDE_DIRS} ${xsimd_INCLUDE_DIRS} ${xtensor_INCLUDE_DIRS})
-include_directories(${Pythonic_INCLUDE_DIRS})
+include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(${NUMPY_INCLUDE_DIRS})
+include_directories(${Pythran_INCLUDE_DIRS})
 
+link_directories(${Pythran_INCLUDE_DIRS})
 
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
 include(CheckCXXCompilerFlag)
@@ -38,6 +43,7 @@ message("FLAGS           : ${CMAKE_CXX_FLAGS}\n")
 message("Found eigen     : ${EIGEN3_INCLUDE_DIR}")
 message("Found Blitz     : ${BLITZ_INCLUDES} | ${BLITZ_LIBRARIES}")
 message("Found Armadillo : ${ARMADILLO_INCLUDE_DIRS} | ${ARMADILLO_LIBRARIES}")
+message("Found Pythran   : ${Pythran_INCLUDE_DIRS}")
 
 message("Found xtensor   : ${xtensor_INCLUDE_DIRS}")
 message("Found xsimd     : ${xsimd_INCLUDE_DIRS}\n\n")
@@ -69,6 +75,7 @@ add_definitions(-DXTENSOR_USE_XSIMD)
 add_definitions(-DEIGEN_FAST_MATH)
 add_definitions(-DNDEBUG)
 add_definitions(-DUSE_BOOST_SIMD)
+add_definitions(-DENABLE_PYTHON_MODULE)
 
 include_directories(${XTENSOR_INCLUDE_DIR} ${GBENCHMARK_INCLUDE_DIRS})
 
@@ -86,7 +93,8 @@ target_link_libraries(${XTENSOR_BENCHMARK_TARGET}
                       ${GBENCHMARK_LIBRARIES}
                       ${CMAKE_THREAD_LIBS_INIT}
                       ${BLITZ_LIBRARIES}
-                      ${ARMADILLO_LIBRARIES})
+                      ${ARMADILLO_LIBRARIES}
+                      ${PYTHON_LIBRARIES})
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/profile_snip.cpp)
   add_executable(profile_snip

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,18 @@
-eigen
-libblitz
-xsimd
-xtensor
-xtensor-blas
-xtl
+name: xtensor-benchmark
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - eigen
+  - libblitz
+  - armadillo
+  - xsimd
+  - xtensor
+  - xtensor-blas
+  - xtl
+  - cmake
+  - gmp
+  - numpy
+  - python
+  - pip:
+    - pythran

--- a/modules/FindNumpy.cmake
+++ b/modules/FindNumpy.cmake
@@ -1,0 +1,89 @@
+# - Find the NumPy libraries
+# This module finds if NumPy is installed, and sets the following variables
+# indicating where it is.
+#
+# TODO: Update to provide the libraries and paths for linking npymath lib.
+#
+#  NUMPY_FOUND               - was NumPy found
+#  NUMPY_VERSION             - the version of NumPy found as a string
+#  NUMPY_VERSION_MAJOR       - the major version number of NumPy
+#  NUMPY_VERSION_MINOR       - the minor version number of NumPy
+#  NUMPY_VERSION_PATCH       - the patch version number of NumPy
+#  NUMPY_VERSION_DECIMAL     - e.g. version 1.6.1 is 10601
+#  NUMPY_INCLUDE_DIRS        - path to the NumPy include files
+
+#============================================================================
+# Copyright 2012 Continuum Analytics, Inc.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#============================================================================
+
+# Finding NumPy involves calling the Python interpreter
+if(NumPy_FIND_REQUIRED)
+    find_package(PythonInterp REQUIRED)
+else()
+    find_package(PythonInterp)
+endif()
+
+if(NOT PYTHONINTERP_FOUND)
+    set(NUMPY_FOUND FALSE)
+endif()
+
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    "import numpy as n; print(n.__version__); print(n.get_include());"
+    RESULT_VARIABLE _NUMPY_SEARCH_SUCCESS
+    OUTPUT_VARIABLE _NUMPY_VALUES
+    ERROR_VARIABLE _NUMPY_ERROR_VALUE
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT _NUMPY_SEARCH_SUCCESS MATCHES 0)
+    if(NumPy_FIND_REQUIRED)
+        message(FATAL_ERROR
+            "NumPy import failure:\n${_NUMPY_ERROR_VALUE}")
+    endif()
+    set(NUMPY_FOUND FALSE)
+endif()
+
+# Convert the process output into a list
+string(REGEX REPLACE ";" "\\\\;" _NUMPY_VALUES ${_NUMPY_VALUES})
+string(REGEX REPLACE "\n" ";" _NUMPY_VALUES ${_NUMPY_VALUES})
+list(GET _NUMPY_VALUES 0 NUMPY_VERSION)
+list(GET _NUMPY_VALUES 1 NUMPY_INCLUDE_DIRS)
+
+# Make sure all directory separators are '/'
+string(REGEX REPLACE "\\\\" "/" NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIRS})
+
+# Get the major and minor version numbers
+string(REGEX REPLACE "\\." ";" _NUMPY_VERSION_LIST ${NUMPY_VERSION})
+list(GET _NUMPY_VERSION_LIST 0 NUMPY_VERSION_MAJOR)
+list(GET _NUMPY_VERSION_LIST 1 NUMPY_VERSION_MINOR)
+list(GET _NUMPY_VERSION_LIST 2 NUMPY_VERSION_PATCH)
+string(REGEX MATCH "[0-9]*" NUMPY_VERSION_PATCH ${NUMPY_VERSION_PATCH})
+math(EXPR NUMPY_VERSION_DECIMAL
+    "(${NUMPY_VERSION_MAJOR} * 10000) + (${NUMPY_VERSION_MINOR} * 100) + ${NUMPY_VERSION_PATCH}")
+
+find_package_message(NUMPY
+    "Found NumPy: version \"${NUMPY_VERSION}\" ${NUMPY_INCLUDE_DIRS}"
+    "${NUMPY_INCLUDE_DIRS}${NUMPY_VERSION}")
+
+set(NUMPY_FOUND TRUE)

--- a/modules/FindPythran.cmake
+++ b/modules/FindPythran.cmake
@@ -1,0 +1,64 @@
+# - Find the Pythran's Pythonic libraries
+# This module finds if Pythran is installed, and sets the following variables
+# indicating where it is.
+#
+#  Pythran_FOUND              - was Pythran found
+#  Pythran_VERSION            - the version of Pythran found as a string
+#  Pythran_VERSION_MAJOR      - the major version number of Pythran
+#  Pythran_VERSION_MINOR      - the minor version number of Pythran
+#  Pythran_VERSION_PATCH      - the patch version number of Pythran
+#  Pythran_VERSION_DECIMAL    - e.g. version 1.6.1 is 10601
+#  Pythran_INCLUDE_DIRS       - path to the Pythran include files
+
+# Based on FindNumpy.cmake
+# (Copyright 2012 Continuum Analytics, Inc. -- MIT License)
+
+# Finding Pythran involves calling the Python interpreter
+if(Pythran_FIND_REQUIRED)
+    find_package(PythonInterp REQUIRED)
+else()
+    find_package(PythonInterp)
+endif()
+
+if(NOT PYTHONINTERP_FOUND)
+    set(Pythran_FOUND FALSE)
+endif()
+
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    "import logging; logging.getLogger('pythran').disabled = True; import inspect; import os; import pythran; print(pythran.__version__); print(os.path.dirname(inspect.getfile(pythran)));"
+    RESULT_VARIABLE _Pythran_SEARCH_SUCCESS
+    OUTPUT_VARIABLE _Pythran_VALUES
+    ERROR_VARIABLE _Pythran_ERROR_VALUE
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT _Pythran_SEARCH_SUCCESS MATCHES 0)
+    if(Pythran_FIND_REQUIRED)
+        message(FATAL_ERROR
+            "Pythran import failure:\n${_Pythran_ERROR_VALUE}")
+    endif()
+    set(Pythran_FOUND FALSE)
+endif()
+
+# Convert the process output into a list
+string(REGEX REPLACE ";" "\\\\;" _Pythran_VALUES ${_Pythran_VALUES})
+string(REGEX REPLACE "\n" ";" _Pythran_VALUES ${_Pythran_VALUES})
+list(GET _Pythran_VALUES 0 Pythran_VERSION)
+list(GET _Pythran_VALUES 1 Pythran_INCLUDE_DIRS)
+
+# Make sure all directory separators are '/'
+string(REGEX REPLACE "\\\\" "/" Pythran_INCLUDE_DIRS ${Pythran_INCLUDE_DIRS})
+
+# Get the major and minor version numbers
+string(REGEX REPLACE "\\." ";" _Pythran_VERSION_LIST ${Pythran_VERSION})
+list(GET _Pythran_VERSION_LIST 0 Pythran_VERSION_MAJOR)
+list(GET _Pythran_VERSION_LIST 1 Pythran_VERSION_MINOR)
+list(GET _Pythran_VERSION_LIST 2 Pythran_VERSION_PATCH)
+string(REGEX MATCH "[0-9]*" Pythran_VERSION_PATCH ${Pythran_VERSION_PATCH})
+math(EXPR Pythran_VERSION_DECIMAL
+    "(${Pythran_VERSION_MAJOR} * 10000) + (${Pythran_VERSION_MINOR} * 100) + ${Pythran_VERSION_PATCH}")
+
+find_package_message(Pythran
+    "Found Pythran (Pythonic): version \"${Pythran_VERSION}\" ${Pythran_INCLUDE_DIRS}"
+    "${Pythran_INCLUDE_DIRS}${Pythran_VERSION}")
+
+set(Pythran_FOUND TRUE)

--- a/src/benchmark_1D.hpp
+++ b/src/benchmark_1D.hpp
@@ -23,6 +23,7 @@
 #include "xtensor/xarray.hpp"
 
 #include <pythonic/core.hpp>
+#include <pythonic/python/core.hpp>
 #include <pythonic/types/ndarray.hpp>
 #include <pythonic/numpy/random/rand.hpp>
 

--- a/src/benchmark_2D.hpp
+++ b/src/benchmark_2D.hpp
@@ -23,6 +23,7 @@
 #include "xtensor/xarray.hpp"
 
 #include <pythonic/core.hpp>
+#include <pythonic/python/core.hpp>
 #include <pythonic/types/ndarray.hpp>
 #include <pythonic/numpy/random/rand.hpp>
 


### PR DESCRIPTION
I just wanted to run the benchmarks on my machine (MacOS) but I had to fix the following:

- In `environment.yml`: use the conda-forge channel and also install cmake, pythran dependencies and pythran via pip (no conda package available for osx on the "serge-sans-paille" conda channel).

- In `CMakeLists.txt`: download googlebenchmark before adding the googlebenchmark sub-directories.

- In `CMakeLists.txt`: instead of `find_package(Pythonic)`, add `find_package(Pythran)` + everything related to its dependencies (i.e., Python, Numpy). I don't know much about pythran, but I assumed that before this PR the `Pythonic` dependency corresponded to the subpackage that is included in pythran. Is that right? At least I've successfully run all the benchmarks :-).